### PR TITLE
Update set_proxy.sh: Set environment variables with `export` 

### DIFF
--- a/proxy/set_proxy.sh
+++ b/proxy/set_proxy.sh
@@ -1,11 +1,11 @@
-# Non-authenticated HTTP server:
-HTTP_PROXY=http://10.10.1.10:1180
+# Non-authenticated HTTP proxy for HTTPS requests:
+export HTTPS_PROXY=http://10.10.1.10:1180
 
-# Authenticated HTTP server:
-HTTP_PROXY=http://username:password@10.10.1.10:1180
+# Authenticated HTTP proxy for HTTPS requests:
+export HTTPS_PROXY=http://username:password@10.10.1.10:1180
 
-# Non-authenticated HTTPS server:
-HTTPS_PROXY=http://10.10.1.10:1180
+# Non-authenticated HTTP proxy for HTTP requests:
+export HTTP_PROXY=http://10.10.1.10:1180
 
-# Authenticated HTTPS server:
-HTTPS_PROXY=http://username:password@10.10.1.10:1180
+# Authenticated HTTP proxy for HTTP requests:
+export HTTP_PROXY=http://username:password@10.10.1.10:1180


### PR DESCRIPTION
On Linux, environment variables should be set with `export`. The current form in the document only sets a shell variable and will not affect child processes. See https://www.gnu.org/software/bash/manual/bash.html#Environment

To verify this, run

```sh
$ HTTPS_PROXY=http://10.10.1.10:1180

$ python3 -c "import os; print(os.environ['HTTPS_PROXY'])"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'HTTPS_PROXY'

$ export HTTPS_PROXY=http://10.10.1.10:1180

$ python3 -c "import os; print(os.environ['HTTPS_PROXY'])"
http://10.10.1.10:1180
```

Also, proxy protocol is different from request protocol. `HTTPS_PROXY` doesn't mean HTTPS proxy, but the proxy for `https://` requests. For details, see https://github.com/Azure/azure-cli/issues/19456, https://stackoverflow.com/questions/75893379/why-https-proxy-uses-http-url

